### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libapache2-mod-authn-yolo
 Section: web
 Priority: optional
 Maintainer: Hans van Kranenburg <hans@knorrie.org>
-Build-Depends: debhelper (>= 10~), dh-apache2, apache2-dev
+Build-Depends: debhelper, dh-apache2, apache2-dev
 Standards-Version: 4.2.1.2
 Homepage: https://github.com/knorrie/mod-authn-yolo
 Vcs-Browser: https://github.com/knorrie/mod-authn-yolo


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/libapache2-mod-authn-yolo/10006d14-e452-4c59-9a2c-8322ef3611c4.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a5/475ac88b201c52de45c19d1c214a4a12f97c45.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/98/c0d930b1d50f71c419e71aff8f26c17aea643f.debug

No differences were encountered between the control files of package \*\*libapache2-mod-authn-yolo\*\*
### Control files of package libapache2-mod-authn-yolo-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-98c0d930b1d50f71c419e71aff8f26c17aea643f-] {+a5475ac88b201c52de45c19d1c214a4a12f97c45+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/10006d14-e452-4c59-9a2c-8322ef3611c4/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/10006d14-e452-4c59-9a2c-8322ef3611c4/diffoscope)).
